### PR TITLE
Three-Roll Pass Support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.9, <4.0"
-pyroll-core = "^2.0.0b"
+pyroll-core = "^2.0.0b2"
 matplotlib = "^3.6.0"
 Jinja2 = "^3.0.3"
 pluggy = "^1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyroll-report"
-version = "2.0.0b1"
+version = "2.0.0b2"
 description = "PyRoll rolling simulation framework - HTML report generation."
 authors = [
     "Max Weiner <max.weiner@imf.tu-freiberg.de>",

--- a/pyroll/report/unit_display/plots.py
+++ b/pyroll/report/unit_display/plots.py
@@ -144,11 +144,6 @@ def plot_profile(ax: plt.Axes, profile: Profile, color):
         ax.fill(*profile.equivalent_rectangle.boundary.xy, fill=False, color=color, ls="--")
 
 
-def plot_pass_groove_contour(ax: plt.Axes, roll_pass: RollPass):
-    ax.plot(*roll_pass.upper_contour_line.xy, color="k")
-    ax.plot(*roll_pass.lower_contour_line.xy, color="k")
-
-
 @hookimpl(specname="unit_plot")
 def roll_pass_plot(unit):
     """Plot roll pass contour and its profiles"""
@@ -160,7 +155,9 @@ def roll_pass_plot(unit):
         ax.set_aspect("equal", "datalim")
         ax.grid(lw=0.5)
 
-        plot_pass_groove_contour(ax, unit)
+        for cl in unit.contour_lines:
+            ax.plot(*cl.xy, color="k")
+
         plot_profile(ax, unit.in_profile, "red")
         plot_profile(ax, unit.out_profile, "blue")
 


### PR DESCRIPTION
Adapt to recent changes in core regarding roll pass contour lines.
Remove usage of `upper_contour_line` and `lower_contour_line` in favor of `contour_lines`.