### PR TITLE
add owner argument to property_format hook

### DIFF
--- a/pyroll/report/hookspecs.py
+++ b/pyroll/report/hookspecs.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 
 from matplotlib.figure import Figure
 
@@ -20,5 +20,11 @@ def unit_plot(unit: Unit) -> Union[Figure, str]:
 
 
 @hookspec(firstresult=True)
-def property_format(name: str, value: object) -> str:
-    """Format the value of a property as string for display in the report. This hook is first result."""
+def property_format(name: str, value: object, owner: Optional[object]) -> str:
+    """
+    Format the value of a property as string for display in the report. This hook is first result.
+    :param name: the name of the property to format
+    :param value: the value of the property to format
+    :param owner: the owner of the property to format, may be None
+    """
+

--- a/pyroll/report/unit_display/format.py
+++ b/pyroll/report/unit_display/format.py
@@ -43,12 +43,12 @@ def float_format(value: object):
 
 
 @hookimpl(specname="property_format")
-def collection_format(name: str, value: object):
+def collection_format(name: str, value: object, owner: object):
     if (
             isinstance(value, Collection)
             and not isinstance(value, str)
     ):
-        return ", ".join([plugin_manager.hook.property_format(name=name, value=e) for e in value])
+        return ", ".join([plugin_manager.hook.property_format(name=name, value=e, owner=owner) for e in value])
 
 
 @hookimpl(specname="property_format")

--- a/pyroll/report/unit_display/properties.py
+++ b/pyroll/report/unit_display/properties.py
@@ -15,9 +15,9 @@ class DoNotPrint(Exception):
     pass
 
 
-def try_format_property(name: str, value: object):
+def try_format_property(name: str, value: object, owner: object):
     try:
-        return plugin_manager.hook.property_format(name=name, value=value)
+        return plugin_manager.hook.property_format(name=name, value=value, owner=owner)
     except (TypeError, ValueError, DoNotPrint):
         return None
 
@@ -27,7 +27,7 @@ def render_properties_table(instance: ReprMixin):
 
     properties = [
         (n.replace("_", " "), s) for n, v in instance.__attrs__.items()
-        if (s := try_format_property(n, v)) is not None
+        if (s := try_format_property(n, v, instance)) is not None
     ]
 
     return template.render(


### PR DESCRIPTION
Close #15.

Name of argument was chosen as `owner`, since this is more conventional in such cases.